### PR TITLE
Update the code syntax to be compatible with the current Deno deployment platform and update the readme documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
 ## 部署与使用教程
 
+> 在现在的Deno的个人面板中，已经移除了“New Project”按钮，由“New App”替代。其URL也发生了变化 [参考这里](#验证部署)
+
 按照以下步骤，轻松部署你自己的 AstrBot GitHub 加速服务：
 
 1.  **(可选但推荐)** 给本项目点个 [**Star ⭐**](https://github.com/lxfight/astrbot2github)，你的支持是作者更新和维护的动力！
@@ -63,6 +65,12 @@
 `https://<你的项目名>.deno.dev`
 
 如果页面显示 `此地址只用于为astrbot提供更快速的github访问服务` 的信息，则表示你的代理服务已成功部署并正在运行。
+
+在新版本的astrbot中，需要在 **插件市场** 配置插件源，源地址格式：
+
+`https://<App名称>.<组织别名>.deno.net/https://github.com/AstrBotDevs/AstrBot_Plugins_Collection/raw/refs/heads/main/plugins.json`
+
+> `https://github.com/AstrBotDevs/AstrBot_Plugins_Collection/raw/refs/heads/main/plugins.json`是官方仓库提供的插件列表。
 
 ## 注意事项
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@
 
 在新版本的astrbot中，需要在 **插件市场** 配置插件源，源地址格式：
 
-`https://<App名称>.<组织别名>.deno.net/https://github.com/AstrBotDevs/AstrBot_Plugins_Collection/raw/refs/heads/main/plugins.json`
+`https://<App名称>.<组织别名>.deno.net/https://raw.githubusercontent.com/AstrBotDevs/AstrBot_Plugins_Collection/refs/heads/main/plugins.json`
 
-> `https://github.com/AstrBotDevs/AstrBot_Plugins_Collection/raw/refs/heads/main/plugins.json`是官方仓库提供的插件列表。
+> `https://raw.githubusercontent.com/AstrBotDevs/AstrBot_Plugins_Collection/refs/heads/main/plugins.json`是官方仓库提供的插件列表。
 
 ## 注意事项
 

--- a/deno_index.ts
+++ b/deno_index.ts
@@ -1,5 +1,3 @@
-import { serve } from "https://deno.land/std@0.155.0/http/server.ts"; // 或更新到最新稳定版，如 @0.224.0
-
 async function handler(req: Request): Promise<Response> {
   const incomingUrl = new URL(req.url);
   if (incomingUrl.pathname === "/") {
@@ -72,6 +70,7 @@ async function handler(req: Request): Promise<Response> {
   }
 }
 
-console.log("此地址只用于帮助astrbot更快的连接github"); // Deno Deploy 会自动使用 $PORT
-// 监听端口 8000 (本地) 或 Deno Deploy 指定的端口
-serve(handler);
+// 使用 Deno 推荐的 Deno.serve 启动服务
+// 这种方式能让 Deno Deploy 自动管理端口和健康检查，避免部署失败
+Deno.serve(handler);
+


### PR DESCRIPTION
Before:

<img width="2476" height="1802" alt="image" src="https://github.com/user-attachments/assets/a8bf2bda-7808-45d3-93ab-55984d674610" />

After:

<img width="2624" height="1094" alt="image" src="https://github.com/user-attachments/assets/6efe887e-8e66-42f5-96b7-f3bc800b816f" />

## Summary by Sourcery

Switch the Deno entrypoint to use the modern Deno.serve API and update deployment documentation for the current Deno Deploy interface and AstrBot plugin configuration.

Enhancements:
- Replace the deprecated std/http serve import with the built-in Deno.serve server startup API.

Documentation:
- Document the updated Deno Deploy UI flow, including the new New App entrypoint and URL changes.
- Add instructions for configuring AstrBot plugin sources using the deployed Deno app URL and the official plugin list.